### PR TITLE
Make code 2.7 compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pyflakes==0.9.2
 suds-jurko==0.6
 twine==1.5.0
 wheel==0.24.0
+six==1.10.0
+mock==1.3.0

--- a/responsys/client.py
+++ b/responsys/client.py
@@ -1,7 +1,7 @@
 import logging
 from ssl import SSLError
 from time import time
-from urllib.error import URLError
+from six.moves.urllib.error import URLError
 
 from suds.client import Client
 from suds import WebFault

--- a/responsys/tests/test_client.py
+++ b/responsys/tests/test_client.py
@@ -1,8 +1,8 @@
 from time import time
 import unittest
-from unittest.mock import patch, Mock
-from urllib.error import URLError
 
+from mock import patch, Mock
+from six.moves.urllib.error import URLError
 from suds import WebFault
 
 from ..exceptions import (

--- a/responsys/types.py
+++ b/responsys/types.py
@@ -1,5 +1,31 @@
 import re
-from collections import UserDict
+import unicodedata
+
+
+try:
+    str.isnumeric
+except AttributeError:
+    # Python 2.x
+    def is_numeric(s):
+        try:
+            float(s)
+        except ValueError:
+            pass
+        else:
+            return True
+
+        try:
+            unicodedata.numeric(s)
+        except (TypeError, ValueError):
+            pass
+        else:
+            return True
+
+        return False
+else:
+    # Python 3
+    def is_numeric(s):
+        return s.isnumeric()
 
 
 class InteractType(object):
@@ -207,7 +233,7 @@ class MergeResult(InteractType):
         failed = None
         if self.error_message:
             failed = re.findall(r'Record ([0-9]*) =', self.error_message)
-            failed = [f.isnumeric() and int(f) or f for f in failed]
+            failed = [is_numeric(f) and int(f) or f for f in failed]
 
         return failed or []
 
@@ -289,7 +315,7 @@ class RecipientData(InteractType):
         return recipient_data
 
 
-class OptionalData(UserDict, InteractType):
+class OptionalData(dict, InteractType):
     def get_soap_object(self, client):
         optional_data_list = []
         for name, value in self.items():


### PR DESCRIPTION
- Move from use of UserDict to subclassing dict directly since UserDict in
  2.x is an old-style class which makes multiple inheritance and calling
  **init** awkward.
- Use six for things moved in 3.x (urllib.error)
- require mock since mock isn't present at all in 2.x
- Add test for "numericness" of string since str.isnumeric doesn't exist in 2.x
